### PR TITLE
match the implicit assumption for the source estimator in the asymmet…

### DIFF
--- a/fortran/noise_spec.f90
+++ b/fortran/noise_spec.f90
@@ -60,10 +60,15 @@ subroutine qtt_asym(est,lmax,rlmin,rlmax,wx0,wxy0,wx1,wxy1,a0a1,b0b1,a0b1,a1b0,N
     call get_lfac(lmax,gtype,lk2)
     call Kernels_lens(rL,W1(1,:),W2(1,:),SG(1,:,:),'S0')
     call Kernels_lens(rL,W1(2,:),W2(2,:),SG(2,:,:),'G0')
-  case('amp','src')
+  case('amp')
     call get_lfac(lmax,gtype,lk2)
     call Kernels_tau(rL,W1(1,:),W2(1,:),SG(1,1,:),'S0')
     call Kernels_tau(rL,W1(2,:),W2(2,:),SG(2,1,:),'G0')
+  case('src')
+    call get_lfac(lmax,gtype,lk2)
+    call Kernels_tau(rL,W1(1,:),W2(1,:),SG(1,1,:),'S0')
+    call Kernels_tau(rL,W1(2,:),W2(2,:),SG(2,1,:),'G0')
+    SG = SG/4d0
   end select
 
   Nl = 0d0


### PR DESCRIPTION
The noise spectrum for the asymmetric estimator for sources assumes no 1/2 factor in the estimator, while the corresponding normalisation assumes 1/2 factor in the source estimator. I correct this mismatch.   